### PR TITLE
[hasec charter] clarify secure storage restricted scope item

### DIFF
--- a/hasec-charter.html
+++ b/hasec-charter.html
@@ -115,7 +115,8 @@
             <strong>Secure Hardware Crypto API:</strong> Maintenance or extension of the Web Crypto API after the first version. May also define other Crypto API specifically for Secure Hardware.
           </li>
           <li>
-            <strong>Secure Hardware Storage API:</strong> Origin specific storage and retrieval of data. This would prevent access by other applications on the device or even from the hardware depending on the level of security provided.
+            <strong>Secure Hardware Storage API:</strong> Origin specific storage and retrieval of data. This would prevent access by other applications on the device or even from the hardware depending on the level of security provided.  This API could be restricted to be used only by a Secure Worker. It is expected the specification would reference existing Web platform storage specifications, noyt define new storage APIs. Additional APIs defined by the group could provide a way for the Secure Worker to determine whether stored data was already encrypted by the implementation so that the Secure Worker could decide whether to encrypt stored data itself.  The Working Group could decide to make that API also available for querying in Web pages about normal storage implementations outside Secure Workers (to determine if they are encrypted sufficiently).  
+            </li>
           </li>
           <li>
             <strong>Secure Hardware IO:</strong> Means to ask for and obtain user input that is protected against compromised operating system or UA/Browser depending on the level provided. This could return a digitally signed (by the hardware component) response from the user. 


### PR DESCRIPTION
Clarifying these to make it clear these are fairly narrow specs that use existing specs and are fairly small extensions or supplements.
