### PR TITLE
[hasec charter] clarify group can produce RECs

### DIFF
--- a/hasec-charter.html
+++ b/hasec-charter.html
@@ -180,7 +180,7 @@
 
 
         <p>
-          The group may produce Recommendation-Track deliverables within the scope of the Restricted Scope Items of this Charter.  These deliverables, when approved by the Working Group, will be listed on the group’s homepage or the GitHub repo linked from the homepage. Recommendation-Track deliverables will be listed under the Restricted Scope Item in which they fit. Specific Deliverables may also be listed in the Charter, but listing in the Charter requires rechartering.
+          The group may produce Recommendation-Track deliverables within the scope of the Restricted Scope Items of this Charter.  These deliverables, when chosen by the Working Group, will be listed on the group’s homepage or the GitHub repo linked from the homepage, under the Restricted Scope Item in which they fit.  When rechartering, specific Recommendation-Track deliverables could also be listed, but none are listed in this Charter.
         </p>
 
         <h3>Other Deliverables (not W3C Recommendations)</h3>

--- a/hasec-charter.html
+++ b/hasec-charter.html
@@ -180,7 +180,7 @@
 
 
         <p>
-          Deliverables approved by the Working Group will be listed on the group’s homepage or GitHub repo linked from the homepage. Those deliverables will be listed under the Restricted Scope Item in which they fit. Specific Deliverables, identifying their corresponding Restricted Scope Item, may also be listed in this Charter by rechartering. There are no specific deliverables identified at this time.
+          The group may produce Recommendation-Track deliverables within the scope of the Restricted Scope Items of this Charter.  These deliverables, when approved by the Working Group, will be listed on the group’s homepage or the GitHub repo linked from the homepage. Recommendation-Track deliverables will be listed under the Restricted Scope Item in which they fit. Specific Deliverables may also be listed in the Charter, but listing in the Charter requires rechartering.
         </p>
 
         <h3>Other Deliverables (not W3C Recommendations)</h3>


### PR DESCRIPTION
Addresses #42 @swickr
Changed the wording of section 3.1 to make clear the WG can produce RECS without rechartering for RECS that fall under one of the Restricted Scope Items.
