### PR TITLE
[hasec charter] copyright license for some specs

### DIFF
--- a/hasec-charter.html
+++ b/hasec-charter.html
@@ -417,6 +417,15 @@
         href="/2004/01/pp-impl/">W3C Patent Policy Implementation</a>.
       </p>
     </div>
+    <div class="licensing">
+        <h2 id="licensing">Licensing</h2>
+        <p>This Working Group will use the <a 
+        href='http://www.w3.org/Consortium/Legal/copyright-software'>W3C 
+        Software and Document license</a> for all deliverables under
+        the Secure Storage API, Secure IO, and Secure Worker Restricted
+        Scope Items (including related discovery/authentication specification).
+        </p>
+      </div>
     <h2 id="about">About this Charter</h2>
     <p>
       This charter has been created according to <a shape="rect"


### PR DESCRIPTION
Use license that is consistent with Community Groups for specs related to Secure Worker to allow flexible back and forth with a CG and to allow flexibility for these particular specs that do not have incubator spec inputs or current expressed Browser implementation interest.
