### PR TITLE
[hasec charter] typos

### DIFF
--- a/hasec-charter.html
+++ b/hasec-charter.html
@@ -168,7 +168,7 @@
           <li>
             <strong>Secure Hardware Storage API:</strong> Origin specific 
             storage and retrieval of data. This would prevent access by other 
-            applications on the device or even from the hardware depending 
+            applications on the device or even from the operating system depending 
             on the level of security provided. This API could be restricted 
             to be used only by a Secure Worker. This API must use or enhance 
             (an) existing Web Platform storage API(s), not create a new 
@@ -287,7 +287,7 @@
           and chosen by Working Group consensus. All Recommendations
           must have associated use cases describing the scenarios that
           the deliverable is intended to enable. These will be used to
-          guide specification development. use cases are not normative
+          guide specification development. Use cases are not normative
           interoperability specifications. They are informative, so do
           not need to be in a REC track document.
         </p>


### PR DESCRIPTION
says "hardware" where it means "operating system" as elsewhere in the Charter.  Capitalizing first word of sentence.
