### PR TITLE
Add non-normative mention about new Japanese ID card.

### DIFF
--- a/hbss.html
+++ b/hbss.html
@@ -141,10 +141,11 @@
 		<p>
 		As of 2016, a large number of European countries have already deployed electronic identity systems and offer their citizens access to government services such as paying tax or managing pensions. Examples of countries and associated systems are:</p>
 		<ul>
-			<li>Estonia: eEstonia</li>
 			<li>Belgium: eID with eService ecosystem</li>
-			<li>Sweden: Tax Agency card and Telia eID</li>
+			<li>Estonia: eEstonia</li>
+			<li>Japan: Individual Number Card (My Number Card)</li>
 			<li>Norway: ID-porten</li>
+			<li>Sweden: Tax Agency card and Telia eID</li>
 		</ul>
 		<p>
 		All the deployed solutions are relying on middleware deployment on citizen devices. </p>


### PR DESCRIPTION
Minor editorial change - mention the new Japanese ID card that got deployed in 2016. (Also, re-arrange the country names in alphabetical order as a minor neutrality nit)
